### PR TITLE
Add pushback and quota signal support via RetryAfterError

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The [examples/](examples/) directory contains standalone programs showing how to
 - **[Fallback Strategies](examples/fallback/main.go)**: Returning stale data when all attempts fail.
 - **[Stateful Rotation](examples/stateful/main.go)**: Rotating API endpoints using `RetryState`.
 - **[Circuit Breaker](examples/circuitbreaker/main.go)**: Layering defensive strategies.
+- **[Pushback Signal](examples/pushback/main.go)**: Aborting retries immediately using `CancelAllRetries`.
 
 ---
 
@@ -107,7 +108,7 @@ data, err := resile.DoState(ctx, func(ctx context.Context, state resile.RetrySta
 ```
 
 ### 5. Handling Rate Limits (Retry-After)
-Resile automatically detects if an error implements `RetryAfterError` and overrides the jittered backoff with the server-dictated duration.
+Resile automatically detects if an error implements `RetryAfterError`. It can override the jittered backoff with a server-dictated duration and can also signal immediate termination (pushback).
 
 ```go
 type RateLimitError struct {
@@ -117,6 +118,10 @@ type RateLimitError struct {
 func (e *RateLimitError) Error() string { return "too many requests" }
 func (e *RateLimitError) RetryAfter() time.Duration {
     return time.Until(e.WaitUntil)
+}
+func (e *RateLimitError) CancelAllRetries() bool {
+    // Return true to abort the entire retry loop immediately.
+    return false 
 }
 
 // Resile will sleep exactly until WaitUntil when this error is encountered.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -90,14 +90,17 @@ The architecture defines a specific interface to identify dynamically calculated
 
 Go
 
-type RetryAfterError interface {  
-    error  
-    RetryAfter() time.Duration  
+type RetryAfterError interface {
+    error
+    RetryAfter() time.Duration
+    CancelAllRetries() bool
 }
 
 When the user's action closure executes an HTTP request, it is responsible for inspecting the response headers. If a 429 or 503 status code is encountered, the closure must parse the Retry-After header. The HTTP specification permits this header to be either an integer representing delay-seconds or a full HTTP-date string.50 The user's application logic parses this value, calculates the required time.Duration, and returns a custom error struct that implements the RetryAfterError interface.48
 
-Within the core execution loop, before calculating the Full Jitter backoff, the retry engine utilizes Go's errors.As functionality to inspect the returned error stack. If the error resolves to an implementation of RetryAfterError, the backoff engine detects this assertion.52 It immediately suspends the standard AWS Full Jitter calculation for that specific attempt and rigidly enforces the exact sleep duration specified by the server.48 This creates an adaptive resilience mechanism that scales gracefully from handling random packet loss to strictly obeying enterprise API traffic controllers.52
+Additionally, the CancelAllRetries() method allows the error to signal a permanent rejection or a pushback that should terminate the entire retry loop immediately. This is useful for handling exhausted quotas or specific server-dictated terminal states (e.g., gRPC pushback with negative delay).
+
+Within the core execution loop, before calculating the Full Jitter backoff, the retry engine utilizes Go's errors.As functionality to inspect the returned error stack. If the error resolves to an implementation of RetryAfterError, the backoff engine detects this assertion.52 It first checks CancelAllRetries(); if it returns true, the retry loop is aborted immediately. Otherwise, it suspends the standard AWS Full Jitter calculation for that specific attempt and rigidly enforces the exact sleep duration specified by the server.48 This creates an adaptive resilience mechanism that scales gracefully from handling random packet loss to strictly obeying enterprise API traffic controllers.52
 
 ## **Concurrency, Context, and Goroutine Lifecycle Management**
 
@@ -328,12 +331,13 @@ The backoff engine defaults to the AWS Full Jitter algorithm.3 However, it must 
 
 Go
 
-type RetryAfterError interface {  
-    error  
-    RetryAfter() time.Duration  
+type RetryAfterError interface {
+    error
+    RetryAfter() time.Duration
+    CancelAllRetries() bool
 }
 
-If errors.As(err, \&retryAfterErr) evaluates to true, the backoff engine ignores the Full Jitter calculation and rigidly sleeps for the specified duration. By strictly adhering to the "Errors are Values" philosophy of modern Go, developers can construct robust and expressive routing loops.
+If errors.As(err, \&retryAfterErr) evaluates to true, the engine first checks CancelAllRetries() to determine if the retry loop should be aborted. If not, it ignores the Full Jitter calculation and rigidly sleeps for the specified duration. By strictly adhering to the "Errors are Values" philosophy of modern Go, developers can construct robust and expressive routing loops.
 
 ### **5\. Telemetry and Hook Interfaces**
 

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -24,6 +24,9 @@ func (e *MyAPIError) Error() string { return "too many requests (HTTP 429)" }
 func (e *MyAPIError) RetryAfter() time.Duration {
 	return time.Until(e.WaitUntil)
 }
+func (e *MyAPIError) CancelAllRetries() bool {
+	return false
+}
 
 func main() {
 	ctx := context.Background()

--- a/examples/pushback/main.go
+++ b/examples/pushback/main.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Onur Cinar.
+// The source code is provided under MIT License.
+// https://github.com/cinar/resile
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/cinar/resile"
+	"github.com/cinar/resile/telemetry/resileslog"
+)
+
+// QuotaExceededError implements RetryAfterError to signal a pushback.
+type QuotaExceededError struct{}
+
+func (e *QuotaExceededError) Error() string { return "quota exhausted (HTTP 429)" }
+func (e *QuotaExceededError) RetryAfter() time.Duration {
+	return 0 // Irrelevant as we are cancelling all retries.
+}
+func (e *QuotaExceededError) CancelAllRetries() bool {
+	return true // Pushback signal: abort all retries immediately.
+}
+
+func main() {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	fmt.Println("--- Pushback and Quota Signal Example ---")
+
+	val, err := resile.Do(ctx, func(ctx context.Context) (string, error) {
+		fmt.Println("Attempting to process mission-critical payload...")
+
+		// Simulate a situation where the server returns a terminal quota error.
+		// Even though we have 5 attempts configured, this should stop after the first.
+		return "", &QuotaExceededError{}
+	},
+		resile.WithName("process-payload"),
+		resile.WithInstrumenter(resileslog.New(logger)),
+		resile.WithMaxAttempts(5),
+	)
+
+	if err != nil {
+		fmt.Printf("Operation failed with terminal state: %v\n", err)
+	} else {
+		fmt.Printf("Operation success: %s\n", val)
+	}
+
+	fmt.Println("Done. Notice that the retry loop terminated after exactly 1 attempt.")
+}

--- a/policy.go
+++ b/policy.go
@@ -38,10 +38,11 @@ func isFatal(err error) bool {
 
 // RetryAfterError is implemented by errors that specify how long to wait before retrying.
 // This is commonly used with HTTP 429 (Too Many Requests) or 503 (Service Unavailable)
-// to respect Retry-After headers.
+// to respect Retry-After headers. It also supports pushback signals to cancel all retries.
 type RetryAfterError interface {
 	error
 	RetryAfter() time.Duration
+	CancelAllRetries() bool
 }
 
 // retryPolicy defines the logic to determine if an error is retriable.

--- a/retry.go
+++ b/retry.go
@@ -258,6 +258,9 @@ func (c *Config) execute(ctx context.Context, action doAction) error {
 		// Check for Retry-After override.
 		var retryAfter RetryAfterError
 		if errors.As(lastErr, &retryAfter) {
+			if retryAfter.CancelAllRetries() {
+				return lastErr
+			}
 			delay = retryAfter.RetryAfter()
 		}
 
@@ -343,6 +346,13 @@ func (c *Config) executeHedged(ctx context.Context, action doAction) error {
 
 			// Check for circuit open to avoid further retries.
 			if errors.Is(lastErr, circuit.ErrCircuitOpen) {
+				cancel()
+				return lastErr
+			}
+
+			// Check for pushback signal to cancel all retries.
+			var retryAfter RetryAfterError
+			if errors.As(lastErr, &retryAfter) && retryAfter.CancelAllRetries() {
 				cancel()
 				return lastErr
 			}

--- a/retry_test.go
+++ b/retry_test.go
@@ -112,11 +112,16 @@ func TestRetryLoop_Success(t *testing.T) {
 
 type mockRetryAfter struct {
 	error
-	delay time.Duration
+	delay  time.Duration
+	cancel bool
 }
 
 func (m *mockRetryAfter) RetryAfter() time.Duration {
 	return m.delay
+}
+
+func (m *mockRetryAfter) CancelAllRetries() bool {
+	return m.cancel
 }
 
 func (m *mockRetryAfter) Unwrap() error {
@@ -135,7 +140,7 @@ func TestRetryLoop_RetryAfter(t *testing.T) {
 
 	start := time.Now()
 	err := config.execute(ctx, func(ctx context.Context, _ RetryState) error {
-		return &mockRetryAfter{errTest, expectedDelay}
+		return &mockRetryAfter{error: errTest, delay: expectedDelay, cancel: false}
 	})
 	duration := time.Since(start)
 
@@ -146,6 +151,29 @@ func TestRetryLoop_RetryAfter(t *testing.T) {
 	// We expect roughly 10ms sleep.
 	if duration < expectedDelay {
 		t.Errorf("expected sleep of at least %v, got %v", expectedDelay, duration)
+	}
+}
+
+func TestRetryLoop_CancelAllRetries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	config := DefaultConfig()
+	config.MaxAttempts = 5
+	config.BaseDelay = 0
+
+	var count uint
+	err := config.execute(ctx, func(ctx context.Context, _ RetryState) error {
+		count++
+		return &mockRetryAfter{error: errTest, delay: 0, cancel: true}
+	})
+
+	if count != 1 {
+		t.Errorf("expected only 1 attempt due to pushback, got %d", count)
+	}
+
+	if !errors.Is(err, errTest) {
+		t.Errorf("expected %v, got %v", errTest, err)
 	}
 }
 
@@ -472,4 +500,28 @@ func TestRetryerInterface_Hedged(t *testing.T) {
 			t.Errorf("expected 2 attempts, got %d", atomic.LoadInt32(&count))
 		}
 	})
+}
+
+func TestDoHedged_CancelAllRetries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var count int32
+	_, err := DoHedged(ctx, func(ctx context.Context) (string, error) {
+		attempt := atomic.AddInt32(&count, 1)
+		if attempt == 1 {
+			return "", &mockRetryAfter{error: errTest, delay: 0, cancel: true}
+		}
+		// Second attempt might start but should be canceled.
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+			return "", errOther
+		}
+	}, WithMaxAttempts(3), WithHedgingDelay(10*time.Millisecond))
+
+	if !errors.Is(err, errTest) {
+		t.Errorf("expected %v, got %v", errTest, err)
+	}
 }


### PR DESCRIPTION
# Pull Request

## Description

- Expanded RetryAfterError interface with CancelAllRetries() bool.
- Updated sequential and hedged execution to respect pushback signals.
- Added comprehensive tests for sequential and hedged pushback scenarios.
- Added new 'pushback' example and updated existing documentation.

Fixes #7 

