### PR TITLE
Implement panic recovery for resilience (issue-17)

### DIFF
--- a/options.go
+++ b/options.go
@@ -114,3 +114,11 @@ func WithAdaptiveBucket(bucket *AdaptiveBucket) Option {
 		c.AdaptiveBucket = bucket
 	}
 }
+
+// WithPanicRecovery enables recovering from panics during execution.
+// If a panic occurs, it is converted into a PanicError and treated as a retryable error.
+func WithPanicRecovery() Option {
+	return func(c *Config) {
+		c.RecoverPanics = true
+	}
+}

--- a/panic_recovery_test.go
+++ b/panic_recovery_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Onur Cinar.
+// The source code is provided under MIT License.
+// https://github.com/cinar/resile
+
+package resile
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPanicRecovery(t *testing.T) {
+	t.Run("Default Behavior Panics", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected panic, but did not get one")
+			}
+		}()
+
+		_, _ = Do(context.Background(), func(ctx context.Context) (string, error) {
+			panic("test panic")
+		})
+	})
+
+	t.Run("WithPanicRecovery Catches Panic", func(t *testing.T) {
+		val, err := Do(context.Background(), func(ctx context.Context) (string, error) {
+			panic("test panic")
+		}, WithPanicRecovery(), WithMaxAttempts(1))
+
+		if val != "" {
+			t.Errorf("expected empty value, got %v", val)
+		}
+
+		var panicErr *PanicError
+		if !errors.As(err, &panicErr) {
+			t.Errorf("expected *PanicError, got %T: %v", err, err)
+		} else if panicErr.Value != "test panic" {
+			t.Errorf("expected panic value 'test panic', got %v", panicErr.Value)
+		}
+	})
+
+	t.Run("Panics are Retried", func(t *testing.T) {
+		attempts := 0
+		_, err := Do(context.Background(), func(ctx context.Context) (string, error) {
+			attempts++
+			if attempts < 3 {
+				panic("transient panic")
+			}
+			return "success", nil
+		}, WithPanicRecovery(), WithMaxAttempts(5), WithBaseDelay(1*time.Millisecond))
+
+		if err != nil {
+			t.Errorf("expected success, got error: %v", err)
+		}
+
+		if attempts != 3 {
+			t.Errorf("expected 3 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("Hedged Panics are Recovered", func(t *testing.T) {
+		val, err := DoHedged(context.Background(), func(ctx context.Context) (string, error) {
+			panic("hedged panic")
+		}, WithPanicRecovery(), WithMaxAttempts(2), WithHedgingDelay(10*time.Millisecond))
+
+		if val != "" {
+			t.Errorf("expected empty value, got %v", val)
+		}
+
+		var panicErr *PanicError
+		if !errors.As(err, &panicErr) {
+			t.Errorf("expected *PanicError, got %T: %v", err, err)
+		}
+	})
+}

--- a/retry.go
+++ b/retry.go
@@ -7,6 +7,7 @@ package resile
 import (
 	"context"
 	"errors"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -25,6 +26,17 @@ type Retryer interface {
 	DoErrHedged(ctx context.Context, action func(context.Context) error) error
 }
 
+// PanicError represents a recovered panic during execution.
+type PanicError struct {
+	Value      any
+	StackTrace string
+}
+
+// Error implements the error interface.
+func (p *PanicError) Error() string {
+	return "panic: " + p.StackTrace
+}
+
 // Config represents the configuration for the retry execution.
 type Config struct {
 	Name           string
@@ -38,6 +50,7 @@ type Config struct {
 	CircuitBreaker *circuit.Breaker
 	Fallback       any
 	AdaptiveBucket *AdaptiveBucket
+	RecoverPanics  bool
 }
 
 // Do executes an action with retry logic using the provided options.
@@ -397,14 +410,29 @@ func (c *Config) executeHedged(ctx context.Context, action doAction) error {
 }
 
 // executeOnce performs a single attempt and triggers instrumentation.
-func (c *Config) executeOnce(ctx context.Context, action doAction, state RetryState) error {
+func (c *Config) executeOnce(ctx context.Context, action doAction, state RetryState) (err error) {
 	// Invoke instrumentation before attempt.
 	if c.Instrumenter != nil {
 		ctx = c.Instrumenter.BeforeAttempt(ctx, state)
 	}
 
 	// Execute the user closure.
-	err := action(ctx, state)
+	if c.RecoverPanics {
+		defer func() {
+			if r := recover(); r != nil {
+				err = &PanicError{
+					Value:      r,
+					StackTrace: string(debug.Stack()),
+				}
+				// Update state for AfterAttempt.
+				state.LastError = err
+				if c.Instrumenter != nil {
+					c.Instrumenter.AfterAttempt(ctx, state)
+				}
+			}
+		}()
+	}
+	err = action(ctx, state)
 
 	// Update state for AfterAttempt.
 	state.LastError = err


### PR DESCRIPTION
# Pull Request

## Description

- Added WithPanicRecovery functional option to enable panic handling.
- Introduced PanicError to encapsulate recovered panic values and stack traces.
- Modified execution logic to treat recovered panics as retryable errors.
- Added comprehensive unit tests for sequential and hedged execution.

Fixes #17 
