### PR TITLE
implement native multi-error aggregation (#34)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,6 +17,8 @@ This repository is governed by the architectural specification in `SPEC.md`.
 1.  **Issue Research**: When given an issue number, use `gh issue view <number>` to gather requirements and context.
 2.  **Branch Management**: Always create a new feature branch (e.g., `feat/issue-<number>`) before making any changes.
 3.  **Planning Phase**: You MUST use `enter_plan_mode` to research, design, and present a comprehensive strategy for user approval before starting any implementation.
+4.  **Committing Changes**: Follow the project's commit message style (concise and descriptive). DO NOT use prefixes like `feat:`, `fix:`, or `docs:`.
+5.  **Pull Requests**: Always create a pull request using `gh pr create`. If the work is related to an issue, include `fixes #<number>` in the PR body to automatically link and close the issue upon merging.
 
 ## Strategic Delegation Mandate
 To maintain session efficiency and adhere to specialized workflows (like branch management and cross-reference integrity), you MUST delegate all implementation, review, and documentation tasks to the respective sub-agents:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,10 +13,16 @@ This repository is governed by the architectural specification in `SPEC.md`.
 8.  **Formatting**: Run Go source code formatting at the end.
 9.  **Articles**: With every new feature, write an article about it in `docs/articles/`.
 
-## Strategic Delegation Mandate
-To maintain session efficiency and adhere to specialized workflows (like branch management and cross-reference integrity), you MUST delegate all implementation and documentation tasks to the respective sub-agents:
+## Workflow Mandates
+1.  **Issue Research**: When given an issue number, use `gh issue view <number>` to gather requirements and context.
+2.  **Branch Management**: Always create a new feature branch (e.g., `feat/issue-<number>`) before making any changes.
+3.  **Planning Phase**: You MUST use `enter_plan_mode` to research, design, and present a comprehensive strategy for user approval before starting any implementation.
 
-- **Implementation:** Always delegate the implementation of features, bug fixes, and unit tests to the `code-writer` sub-agent.
-- **Documentation:** Always delegate the creation of technical articles, README updates, and documentation cross-referencing to the `technical-writer` sub-agent.
-- **Orchestration:** Act as the high-level orchestrator. Your responsibility is to define the strategy, coordinate the sub-agents, and perform the final verification of their work against the original request.
-- **Direct Action:** Only perform implementation or documentation tasks directly in the main session if a sub-agent is technically unable to complete a specific, narrow task or if the user explicitly overrides this mandate with a direct instruction for a specific turn.
+## Strategic Delegation Mandate
+To maintain session efficiency and adhere to specialized workflows (like branch management and cross-reference integrity), you MUST delegate all implementation, review, and documentation tasks to the respective sub-agents:
+
+- **Implementation**: Always delegate the implementation of features, bug fixes, and unit tests to the `code-writer` sub-agent.
+- **Review**: Always delegate code quality and architectural reviews to the `code-reviewer` sub-agent.
+- **Documentation**: Always delegate the creation of technical articles, README updates, and documentation cross-referencing to the `technical-writer` sub-agent.
+- **Orchestration**: Act as the high-level orchestrator. Your responsibility is to define the strategy, coordinate the sub-agents, and perform the final verification of their work against the original request.
+- **Direct Action**: Only perform implementation or documentation tasks directly in the main session if a sub-agent is technically unable to complete a specific, narrow task or if the user explicitly overrides this mandate with a direct instruction for a specific turn.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - [Marking Errors as Fatal](#17-marking-errors-as-fatal)
   - [Custom Error Filtering](#18-custom-error-filtering)
   - [Policy Composition & Chaining](#19-policy-composition--chaining)
+  - [Native Multi-Error Aggregation](#20-native-multi-error-aggregation)
   - [Configuration Reference](#configuration-reference)
 
 - [Architecture & Design](#architecture--design)
@@ -66,15 +67,16 @@ In distributed systems, transient failures are a mathematical certainty. Resile 
 
 Want to learn more about the philosophy behind Resile and advanced resilience patterns in Go? Check out these deep dives:
 
-* [Stop Writing Manual Retry Loops in Go: Why Your Current Logic is Probably Dangerous](https://dev.to/onurcinar/stop-writing-manual-retry-loops-in-go-why-your-current-logic-is-probably-dangerous-5bj5)
-* [Python's Stamina for Go: Bringing Ergonomic Resilience to Gophers](https://dev.to/onurcinar/pythons-stamina-for-go-bringing-ergonomic-resilience-to-gophers-1lf2)
-* [Beating Tail Latency: A Guide to Request Hedging in Go Microservices](https://dev.to/onurcinar/beating-tail-latency-a-guide-to-request-hedging-in-go-microservices-p81)
-* [Preventing Microservice Meltdowns: Adaptive Retries and Circuit Breakers in Go](https://dev.to/onurcinar/preventing-microservice-meltdowns-adaptive-retries-and-circuit-breakers-in-go-30ho)
-* [Self-Healing State Machines: Resilient State Transitions in Go](https://dev.to/onurcinar/self-healing-state-machines-resilient-state-transitions-in-go-3e0)
+* [Stop Writing Manual Retry Loops in Go: Why Your Current Logic is Probably Dangerous](docs/articles/stop-writing-manual-loops.md)
+* [Python's Stamina for Go: Bringing Ergonomic Resilience to Gophers](docs/articles/python-stamina-for-go.md)
+* [Beating Tail Latency: A Guide to Request Hedging in Go Microservices](docs/articles/beating-tail-latency.md)
+* [Preventing Microservice Meltdowns: Adaptive Retries and Circuit Breakers in Go](docs/articles/preventing-meltdowns.md)
+* [Self-Healing State Machines: Resilient State Transitions in Go](docs/articles/self-healing-state-machines.md)
 * [Resilience Beyond Counters: Sliding Window Circuit Breakers in Go](docs/articles/sliding-window-circuit-breakers.md)
 * [Stop the Domino Effect: Bulkhead Isolation in Go](docs/articles/bulkhead-isolation.md)
 * [Respecting Boundaries: Precise Rate Limiting in Go](docs/articles/rate-limiting.md)
 * [Beyond Static Limits: Adaptive Concurrency with TCP-Vegas in Go](docs/articles/adaptive-concurrency.md)
+* [Debugging the Timeline: Native Multi-Error Aggregation in Go](docs/articles/native-multi-error-aggregation.md)
 
 
 ## Examples
@@ -98,7 +100,7 @@ The [examples/](examples/) directory contains standalone programs showing how to
 ## Common Use Cases
 
 ### 1. Simple Retries
-Retry a simple operation that only returns an error.
+Retry a simple operation that only returns an error. If all retries fail, Resile returns an aggregated error containing the failures from every attempt.
 
 ```go
 err := resile.DoErr(ctx, func(ctx context.Context) error {
@@ -363,11 +365,28 @@ val, err := standardPolicy.Do(ctx, action)
 err := standardPolicy.DoErr(ctx, actionErr)
 ```
 
-In this example:
-1. **Bulkhead** is the outermost layer. It limits total concurrent calls to the whole stack.
-2. **Circuit Breaker** wraps the retry loop. If the whole retry loop fails multiple times, the circuit opens.
-3. **Retry** wraps the timeout and the action. Each retry attempt has its own timeout.
-4. **Timeout** is the innermost layer. It limits how long each individual attempt can take.
+### 20. Native Multi-Error Aggregation
+Resile uses Go 1.20's `errors.Join` to aggregate and return the complete timeline of failures in both standard and hedged retry loops.
+
+```go
+err := resile.DoErr(ctx, action, resile.WithMaxAttempts(3))
+
+if err != nil {
+    // Check if a specific error occurred in any of the attempts
+    if errors.Is(err, context.DeadlineExceeded) {
+        fmt.Println("At least one attempt timed out")
+    }
+
+    // Iterate over the chronological timeline of failures
+    if multi, ok := err.(interface{ Unwrap() []error }); ok {
+        for i, e := range multi.Unwrap() {
+            fmt.Printf("Attempt %d failed: %v\n", i+1, e)
+        }
+    }
+}
+```
+
+[Read more: Debugging the Timeline: Native Multi-Error Aggregation in Go](docs/articles/native-multi-error-aggregation.md)
 
 ---
 

--- a/docs/articles/beating-tail-latency.md
+++ b/docs/articles/beating-tail-latency.md
@@ -58,6 +58,13 @@ data, err := resile.DoHedged(ctx, func(ctx context.Context) (*User, error) {
 3. If the first request hasn't finished, it starts a **second** request.
 4. As soon as one returns a successful result, Resile **cancels the context** of the other request and returns the data to you.
 
+### What if they all fail? (Multi-Error Aggregation)
+In a hedged scenario, you might have multiple concurrent requests failing for different reasons. Resile uses Go 1.20's `errors.Join` to aggregate every failure from every parallel attempt. 
+
+If the primary request fails with a "Network Timeout" and the hedged request fails with a "Service Unavailable," you get both in your error report. This preserves the complete timeline of the failure across all parallel paths.
+
+[Read more: Debugging the Timeline: Native Multi-Error Aggregation in Go](native-multi-error-aggregation.md)
+
 ---
 
 ## Picking the Right Hedging Delay

--- a/docs/articles/native-multi-error-aggregation.md
+++ b/docs/articles/native-multi-error-aggregation.md
@@ -1,0 +1,110 @@
+# Debugging the Timeline: Native Multi-Error Aggregation in Go
+
+When a service call fails after three retries, knowing that it failed is only half the story. The real question is: *How* did it fail? 
+
+Did it timeout twice and then hit a 503? Or did it fail with a DNS error first, followed by a connection refused? In a complex distributed system, the **timeline of failures** is the most valuable piece of evidence you have for debugging transient issues.
+
+Conventional retry loops often throw away this history, returning only the last error encountered. With [Resile](https://github.com/cinar/resile), you get the complete picture using Go 1.20's native multi-error aggregation.
+
+---
+
+## The Problem: The "Last Error Wins" Anti-Pattern
+
+Most manual retry loops look like this:
+
+```go
+var lastErr error
+for i := 0; i < 3; i++ {
+    if err := doWork(); err != nil {
+        lastErr = err
+        continue
+    }
+    return nil
+}
+return lastErr
+```
+
+In this pattern, if your first attempt failed because of a critical configuration error (like an invalid API key) and subsequent attempts failed because the context was cancelled, you would only see `context.Canceled`. The root cause—the configuration error—is lost forever.
+
+## The Solution: Native `errors.Join` Support
+
+Resile leverages `errors.Join`, introduced in Go 1.20, to aggregate every single error encountered during an execution lifecycle. 
+
+Whether you are using standard retries or speculative hedging, Resile preserves the entire sequence of failures. This means you don't just get an error; you get a **chronological audit log** of what went wrong.
+
+### How it Works in Practice
+
+When you execute a function with Resile, and it exhausts all retry attempts, the returned error wraps every intermediate failure.
+
+```go
+err := resile.DoErr(ctx, func(ctx context.Context) error {
+    return fmt.Errorf("attempt failed")
+}, resile.WithMaxAttempts(3))
+
+if err != nil {
+    // Printing the error shows all attempts separated by newlines
+    fmt.Println(err)
+    /*
+       Output:
+       attempt failed
+       attempt failed
+       attempt failed
+    */
+}
+```
+
+### Full Compatibility with `errors.Is` and `errors.As`
+
+Because Resile uses the standard library's multi-error implementation, it remains fully compatible with Go's error inspection primitives. You can check if *any* of the attempts failed for a specific reason:
+
+```go
+if errors.Is(err, context.DeadlineExceeded) {
+    // At least one attempt (likely the last one) timed out
+}
+
+var dnsErr *net.DNSError
+if errors.As(err, &dnsErr) {
+    // One of the attempts encountered a DNS issue
+}
+```
+
+---
+
+## Aggregation in Hedged Retries
+
+Multi-error aggregation is even more critical when using **Request Hedging** (`DoHedged`). In hedging, multiple attempts run concurrently. If they all fail, Resile collects the errors from every parallel execution path and joins them.
+
+This ensures that if your primary request failed with a "Connection Refused" but your speculative "hedged" request failed with a "Read Timeout," you see both in the final error report.
+
+---
+
+## Inspecting the Error Slice
+
+If you need to programmatically iterate over the individual errors (for example, to log them to different systems or count failure types), you can use the `Unwrap() []error` pattern supported by Go 1.20+:
+
+```go
+if err != nil {
+    if multi, ok := err.(interface{ Unwrap() []error }); ok {
+        errs := multi.Unwrap()
+        fmt.Printf("Encountered %d failures across all attempts\n", len(errs))
+        
+        for i, e := range errs {
+            fmt.Printf("Attempt %d: %v\n", i+1, e)
+        }
+    }
+}
+```
+
+---
+
+## Conclusion
+
+Resilience isn't just about keeping the system running; it's about making the system **observable** when things go wrong. By aggregating errors natively, Resile gives you a high-fidelity view of failure modes without the need for custom error types or complex boilerplate.
+
+Stop guessing why your retries are failing. Start seeing the full timeline.
+
+**Explore the Resile Project:** [github.com/cinar/resile](https://github.com/cinar/resile)
+
+How do you handle multi-error reporting in your Go applications? Let's connect on GitHub!
+
+#golang #backend #microservices #observability #distributedsystems

--- a/docs/articles/preventing-meltdowns.md
+++ b/docs/articles/preventing-meltdowns.md
@@ -113,6 +113,12 @@ In this setup:
 3. **The Adaptive Bucket** ensures that even if the breaker hasn't tripped yet, you won't overwhelm the system with aggregate retry load.
 4. **Adaptive Concurrency** prevents your own service from becoming a bottleneck when latency rises, intelligently shedding load before failures occur.
 
+### Observability: Native Multi-Error Aggregation
+
+When a meltdown is occurring, you don't just want the last error—you want the complete picture. Resile uses Go 1.20's `errors.Join` to aggregate every failure from every attempt. This means that if you hit the circuit breaker or the adaptive bucket throttled you, you'll see exactly where and when that happened in the final error report.
+
+[Read more: Debugging the Timeline: Native Multi-Error Aggregation in Go](native-multi-error-aggregation.md)
+
 ---
 
 ## Manual Recovery

--- a/docs/articles/python-stamina-for-go.md
+++ b/docs/articles/python-stamina-for-go.md
@@ -43,6 +43,7 @@ It looks and feels like a simple function call, but under the hood, Resile is do
 *   **AWS Full Jitter Backoff**: Spreading out retries to protect your database.
 *   **Context-Awareness**: Cancelling retries immediately if the request times out.
 *   **Memory Safety**: Using managed timers to prevent goroutine leaks.
+*   **Native Multi-Error Aggregation**: Using Go 1.20's `errors.Join` to return the complete timeline of failures across all attempts.
 
 ---
 

--- a/docs/articles/stop-writing-manual-loops.md
+++ b/docs/articles/stop-writing-manual-loops.md
@@ -20,7 +20,7 @@ Here is why your manual retry logic is probably dangerous, and how to fix it usi
 
 ---
 
-## The 3 Silent Killers of Manual Retries
+## The 4 Silent Killers of Manual Retries
 
 ### 1. The Thundering Herd (Missing Jitter)
 If your service has 1,000 instances and the database goes down for a second, all 1,000 instances will fail at once. With a fixed `time.Sleep(1 * time.Second)`, all 1,000 instances will then wake up at the exact same millisecond and hammer the database again. 
@@ -45,6 +45,9 @@ case <-time.After(delay): // DANGER!
 ```
 
 According to the Go standard library, the timer created by `time.After` **is not garbage collected until it fires**, even if the `ctx.Done()` case is chosen. In a busy service with long retries, this creates a slow-motion memory leak that is incredibly hard to debug.
+
+### 4. The Missing History (Last-Error Bias)
+When a loop retries 3 times and finally gives up, what error does it return? Usually just the last one. If your first attempt failed with an "Authentication Error" but the third one failed with "Context Canceled" because the user hung up, you've lost the most important piece of information for debugging.
 
 ---
 
@@ -83,10 +86,23 @@ Resile implements the industry-standard **Full Jitter** algorithm. Instead of sl
 ### 2. Memory-Safe Timer Management
 Resile doesn't use `time.After`. It uses a managed `time.Timer` with explicit cleanup. Whether your retry succeeds, fails, or the context is cancelled, Resile ensures all resources are returned to the runtime immediately.
 
-### 3. Generic-First API
+### 3. Native Multi-Error Aggregation
+Resile uses Go 1.20's `errors.Join` to return every error encountered during the retry timeline. You don't just see the last failure; you see everything that happened.
+
+```go
+// Printing the error shows all attempts
+fmt.Println(err)
+
+// You can still use standard primitives
+if errors.Is(err, ErrSpecificFailure) { ... }
+```
+
+[Read more: Debugging the Timeline: Native Multi-Error Aggregation in Go](native-multi-error-aggregation.md)
+
+### 4. Generic-First API
 No `interface{}`, no reflection, and no type casting. Because it uses Go Generics, the compiler checks your types at build time. If your function returns a `*User`, Resile returns a `*User`.
 
-### 4. Fast Unit Testing
+### 5. Fast Unit Testing
 One of the biggest pain points of retries is that they slow down your CI/CD pipelines. Who wants to wait 10 seconds for a test to finish because of backoff?
 
 With Resile, you can use `WithTestingBypass` to make all retries execute instantly in your tests:

--- a/multi_error_test.go
+++ b/multi_error_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Onur Cinar.
+// The source code is provided under MIT License.
+// https://github.com/cinar/resile
+
+package resile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestMultiErrorAggregation_Retry(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	err1 := errors.New("error 1")
+	err2 := errors.New("error 2")
+	err3 := errors.New("error 3")
+
+	var count int
+	err := DoErr(ctx, func(ctx context.Context) error {
+		count++
+		switch count {
+		case 1:
+			return err1
+		case 2:
+			return err2
+		case 3:
+			return err3
+		default:
+			return nil
+		}
+	}, WithMaxAttempts(3), WithBaseDelay(0))
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Verify it contains all errors
+	if !errors.Is(err, err1) {
+		t.Errorf("expected error to wrap %v", err1)
+	}
+	if !errors.Is(err, err2) {
+		t.Errorf("expected error to wrap %v", err2)
+	}
+	if !errors.Is(err, err3) {
+		t.Errorf("expected error to wrap %v", err3)
+	}
+
+	// Verify Unwrap() []error support
+	type multiError interface {
+		Unwrap() []error
+	}
+
+	if me, ok := err.(multiError); ok {
+		unwrapped := me.Unwrap()
+		if len(unwrapped) != 3 {
+			t.Errorf("expected 3 unwrapped errors, got %d", len(unwrapped))
+		}
+	} else {
+		t.Error("error does not implement Unwrap() []error")
+	}
+
+	expectedStr := fmt.Sprintf("%v\n%v\n%v", err1, err2, err3)
+	if err.Error() != expectedStr {
+		t.Errorf("expected error string %q, got %q", expectedStr, err.Error())
+	}
+}
+
+func TestMultiErrorAggregation_Hedged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	err1 := errors.New("error 1")
+	err2 := errors.New("error 2")
+
+	err := DoErrStateHedged(ctx, func(ctx context.Context, state RetryState) error {
+		// In hedging, multiple attempts run concurrently.
+		if state.Attempt == 0 {
+			return err1
+		}
+		return err2
+	}, WithMaxAttempts(2), WithHedgingDelay(0))
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, err1) {
+		t.Errorf("expected error to wrap %v", err1)
+	}
+	if !errors.Is(err, err2) {
+		t.Errorf("expected error to wrap %v", err2)
+	}
+}
+
+func TestMultiErrorAggregation_Mixed(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err1 := errors.New("error 1")
+
+	err := DoErr(ctx, func(innerCtx context.Context) error {
+		cancel() // Cancel context during the first attempt
+		return err1
+	}, WithMaxAttempts(3), WithBaseDelay(10*time.Millisecond))
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, err1) {
+		t.Errorf("expected error to wrap %v", err1)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected error to wrap context.Canceled, got %v", err)
+	}
+}
+
+func TestMultiErrorAggregation_Hedged_Stateful(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	err1 := errors.New("error 1")
+	err2 := errors.New("error 2")
+
+	err := DoErrStateHedged(ctx, func(ctx context.Context, state RetryState) error {
+		if state.Attempt == 0 {
+			return err1
+		}
+		return err2
+	}, WithMaxAttempts(2), WithHedgingDelay(0))
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, err1) {
+		t.Errorf("expected error to wrap %v", err1)
+	}
+	if !errors.Is(err, err2) {
+		t.Errorf("expected error to wrap %v", err2)
+	}
+}

--- a/retry.go
+++ b/retry.go
@@ -321,32 +321,36 @@ func (c *Config) timeoutMiddleware(timeout time.Duration) middleware {
 func (c *Config) retryMiddleware() middleware {
 	return func(next doAction) doAction {
 		return func(ctx context.Context, state RetryState) error {
-			var lastErr error
+			errs := make([]error, 0, c.MaxAttempts)
 			start := time.Now()
 
 			for attempt := uint(0); attempt < c.MaxAttempts; attempt++ {
 				state.Attempt = attempt
-				state.LastError = lastErr
+				if len(errs) > 0 {
+					state.LastError = errs[len(errs)-1]
+				}
 				state.TotalDuration = time.Since(start)
 
-				lastErr = next(ctx, state)
+				err := next(ctx, state)
 
 				// Success terminates the loop.
-				if lastErr == nil {
+				if err == nil {
 					if c.AdaptiveBucket != nil {
 						c.AdaptiveBucket.AddSuccessToken()
 					}
 					return nil
 				}
 
+				errs = append(errs, err)
+
 				// Check for circuit open to avoid retries.
-				if errors.Is(lastErr, circuit.ErrCircuitOpen) {
-					return lastErr
+				if errors.Is(err, circuit.ErrCircuitOpen) {
+					return errors.Join(errs...)
 				}
 
 				// Check if we should retry based on the error policy.
-				if !c.Policy.shouldRetry(lastErr) {
-					return lastErr
+				if !c.Policy.shouldRetry(err) {
+					return errors.Join(errs...)
 				}
 
 				// If this was the last attempt, don't sleep.
@@ -364,9 +368,9 @@ func (c *Config) retryMiddleware() middleware {
 
 				// Check for Retry-After override.
 				var retryAfter RetryAfterError
-				if errors.As(lastErr, &retryAfter) {
+				if errors.As(err, &retryAfter) {
 					if retryAfter.CancelAllRetries() {
-						return lastErr
+						return errors.Join(errs...)
 					}
 					delay = retryAfter.RetryAfter()
 				}
@@ -374,11 +378,11 @@ func (c *Config) retryMiddleware() middleware {
 				// Sleep safely with context awareness.
 				if err := sleep(ctx, delay); err != nil {
 					// Context canceled during sleep.
-					return errors.Join(lastErr, err)
+					return errors.Join(append(errs, err)...)
 				}
 			}
 
-			return lastErr
+			return errors.Join(errs...)
 		}
 	}
 }
@@ -467,7 +471,7 @@ func (c *Config) executeHedged(ctx context.Context, action doAction) error {
 	defer cancel()
 
 	results := make(chan error, c.MaxAttempts)
-	var lastErr error
+	errs := make([]error, 0, c.MaxAttempts)
 	var inFlight int
 	var attemptsStarted uint
 
@@ -541,7 +545,7 @@ func (c *Config) executeHedged(ctx context.Context, action doAction) error {
 			if timer != nil {
 				timer.Stop()
 			}
-			return ctx.Err()
+			return errors.Join(append(errs, ctx.Err())...)
 		case err := <-results:
 			if timer != nil {
 				timer.Stop()
@@ -554,25 +558,25 @@ func (c *Config) executeHedged(ctx context.Context, action doAction) error {
 				}
 				return nil
 			}
-			lastErr = err
+			errs = append(errs, err)
 
 			// Check for circuit open to avoid further retries.
-			if errors.Is(lastErr, circuit.ErrCircuitOpen) {
+			if errors.Is(err, circuit.ErrCircuitOpen) {
 				cancel()
-				return lastErr
+				return errors.Join(errs...)
 			}
 
 			// Check for pushback signal to cancel all retries.
 			var retryAfter RetryAfterError
-			if errors.As(lastErr, &retryAfter) && retryAfter.CancelAllRetries() {
+			if errors.As(err, &retryAfter) && retryAfter.CancelAllRetries() {
 				cancel()
-				return lastErr
+				return errors.Join(errs...)
 			}
 
 			// If error is not retryable, cancel all and return.
-			if !c.Policy.shouldRetry(lastErr) {
+			if !c.Policy.shouldRetry(err) {
 				cancel()
-				return lastErr
+				return errors.Join(errs...)
 			}
 
 			// If no more attempts are in-flight, start next one immediately.
@@ -584,7 +588,7 @@ func (c *Config) executeHedged(ctx context.Context, action doAction) error {
 		}
 	}
 
-	return lastErr
+	return errors.Join(errs...)
 }
 
 type contextKey string


### PR DESCRIPTION
This PR implements native multi-error aggregation using Go 1.20's errors.Join in both standard and hedged retry loops. This prevents the loss of critical debugging context by returning the complete timeline of failures encountered during an exhausted retry sequence. fixes #34