### PR TITLE
Example: Streaming HTTP Response Resumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
   - [Native Multi-Error Aggregation](#21-native-multi-error-aggregation)
   - [Native Chaos Engineering (Fault & Latency Injection)](#22-native-chaos-engineering-fault--latency-injection)
   - [Distributed Deadline Propagation](#23-distributed-deadline-propagation)
+  - [Reliable File Downloads (HTTP Resumption)](#24-reliable-file-downloads-http-resumption)
   - [Configuration Reference](#configuration-reference)
 
 - [Architecture & Design](#architecture--design)
@@ -84,6 +85,7 @@ Want to learn more about the philosophy behind Resile and advanced resilience pa
 * [Debugging the Timeline: Native Multi-Error Aggregation in Go](docs/articles/native-multi-error-aggregation.md)
 * [Native Chaos Engineering: Testing Resilience with Fault & Latency Injection](docs/articles/chaos-engineering.md)
 * [Stopping the Zombie Requests: Distributed Deadline Propagation in Go](docs/articles/distributed-deadline-propagation.md)
+* [Reliable File Downloads with HTTP Range Resumption](docs/articles/streaming-http-resumption.md)
 
 
 ## Examples
@@ -103,6 +105,7 @@ The [examples/](examples/) directory contains standalone programs showing how to
 - **[Panic Recovery](examples/panicrecovery/main.go)**: Implementing Erlang's "Let It Crash" philosophy.
 - **[State Machine](examples/statemachine/main.go)**: Building resilient state machines inspired by Erlang's `gen_statem`.
 - **[Chaos Injection](examples/chaos/main.go)**: Simulating faults and latency to test your policies.
+- **[HTTP Resumption](examples/http_resume_stream/main.go)**: Resuming large file downloads using HTTP Range.
 
 ---
 
@@ -450,6 +453,29 @@ resile.InjectDeadlineHeader(ctx, md, "Grpc-Timeout") // Standard gRPC format
 ```
 
 [Read more: Stopping the Zombie Requests: Distributed Deadline Propagation in Go](docs/articles/distributed-deadline-propagation.md)
+
+### 24. Reliable File Downloads (HTTP Resumption)
+Combine `DoErr` with HTTP `Range` headers to resume large downloads from the last successful byte instead of restarting from zero.
+
+```go
+var bytesReceived int64
+err := resile.DoErr(ctx, func(ctx context.Context) error {
+    req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+    if bytesReceived > 0 {
+        req.Header.Set("Range", fmt.Sprintf("bytes=%d-", bytesReceived))
+    }
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil { return err }
+    defer resp.Body.Close()
+    
+    // ... handle status code and open file ...
+    n, err := io.Copy(file, resp.Body)
+    bytesReceived += n
+    return err
+}, resile.WithMaxAttempts(10))
+```
+
+[Read more: Reliable File Downloads with HTTP Range Resumption](docs/articles/streaming-http-resumption.md)
 
 ---
 

--- a/docs/articles/stop-writing-manual-loops.md
+++ b/docs/articles/stop-writing-manual-loops.md
@@ -131,6 +131,9 @@ Resile isn't just a retry loop; it's a resilience toolkit. Out of the box, you g
 - **Circuit Breaker Integration**: Stop retrying when a service is fundamentally down.
 - **Panic Recovery**: Convert unexpected panics into retryable errors (the Erlang "Let It Crash" way).
 - **Distributed Deadline Propagation**: Abort zombie requests early and inject timeout headers.
+- **Stateful Resumption**: Automatically handle partial failures by resuming from the last successful byte (e.g., in large downloads).
+
+[Read more: Reliable File Downloads with HTTP Range Resumption](streaming-http-resumption.md)
 
 ---
 

--- a/docs/articles/streaming-http-resumption.md
+++ b/docs/articles/streaming-http-resumption.md
@@ -1,0 +1,110 @@
+# Reliable File Downloads with HTTP Range Resumption
+
+Imagine you're downloading a 2GB database backup or a large media asset over an unstable mobile connection. You've reached 95%, and then—*click*—the connection drops. A standard retry mechanism might kick in, but it starts the download from 0%. You've just wasted 1.9GB of bandwidth, and the next attempt might fail at 98%.
+
+This is the "Sisyphean Download" problem. To solve it, we need a way to pick up exactly where we left off.
+
+In this article, we'll explore how to implement reliable, resumable file downloads in Go using the HTTP `Range` header and the [Resile](https://github.com/cinar/resile) resilience library.
+
+---
+
+## The Challenge: Unstable Connections & Wasted Bandwidth
+
+Standard HTTP GET requests fetch the entire resource. If the connection is interrupted, the partial data is often discarded, and the client must restart the request. In environments with high latency or intermittent connectivity (like satellite, mobile, or edge computing), this leads to:
+
+1.  **Increased Latency:** Total time to successful download skyrockets.
+2.  **Bandwidth Waste:** Multiple failed attempts consume significantly more data than the file size.
+3.  **Server Load:** The server spends resources re-sending the same bytes repeatedly.
+
+---
+
+## The Solution: HTTP `Range` Requests
+
+The HTTP/1.1 protocol introduced the `Range` request header. It allows a client to request only a specific portion of a resource.
+
+For example, if you already have the first 1,024 bytes of a file, you can request the rest by sending:
+`Range: bytes=1024-`
+
+If the server supports this, it will respond with a `206 Partial Content` status code and only the requested bytes. If it doesn't support ranges, it will typically return `200 OK` and send the entire file from the beginning.
+
+---
+
+## Implementing Resumption with Resile
+
+Resile's `DoErr` (or `Do`) function is perfect for wrapping this logic. By maintaining the download state *outside* the retry closure, we can dynamically adjust each retry attempt to request only the missing data.
+
+### 1. Track the State
+We need a variable to keep track of how many bytes we've successfully written to our local file.
+
+```go
+var bytesReceived int64
+```
+
+### 2. Configure the Retry Policy
+We'll use `resile.DoErr` with an exponential backoff to give the network time to recover between attempts.
+
+```go
+err := resile.DoErr(ctx, func(ctx context.Context) error {
+    req, _ := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)
+
+    // If we have partial data, ask for the rest.
+    if bytesReceived > 0 {
+        req.Header.Set("Range", fmt.Sprintf("bytes=%d-", bytesReceived))
+    }
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        return err // Retry on network errors
+    }
+    defer resp.Body.Close()
+
+    // Handle Server Response
+    fileFlags := os.O_APPEND | os.O_CREATE | os.O_WRONLY
+    if resp.StatusCode == http.StatusOK {
+        // Server doesn't support Range or we're starting fresh.
+        bytesReceived = 0
+        fileFlags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+    } else if resp.StatusCode != http.StatusPartialContent {
+        return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+    }
+
+    // Open the local file for writing/appending.
+    f, _ := os.OpenFile(localPath, fileFlags, 0644)
+    defer f.Close()
+
+    // Stream the body and update our state.
+    // io.Copy returns the number of bytes written before any error.
+    n, err := io.Copy(f, resp.Body)
+    bytesReceived += n 
+
+    return err // If io.Copy fails (e.g., connection drop), Resile retries.
+}, 
+    resile.WithMaxAttempts(10),
+    resile.WithBackoff(resile.NewFullJitter(100*time.Millisecond, 2*time.Second)),
+)
+```
+
+---
+
+## Why This Works
+
+1.  **State Persistence:** The `bytesReceived` variable lives outside the retry loop. When `io.Copy` fails due to a connection drop, it returns the number of bytes it *did* manage to write. We add this to `bytesReceived`.
+2.  **Adaptive Retries:** On the next retry attempt, the closure runs again. It sees that `bytesReceived > 0` and automatically adds the `Range` header to the new request.
+3.  **Graceful Fallback:** If the server doesn't support ranges (returns `200 OK`), the code resets `bytesReceived` and starts over, ensuring the download still completes eventually.
+4.  **Backoff & Jitter:** Using Resile's `WithBackoff` prevents "thundering herd" issues if multiple clients are trying to resume downloads from the same failing server.
+
+---
+
+## Real-World Considerations
+
+-   **File Integrity:** For mission-critical files, always verify the checksum (SHA-256) after the download completes to ensure no corruption occurred during the multiple resumption steps.
+-   **ETags/Last-Modified:** Ideally, you should also track the `ETag` or `Last-Modified` header. If the file on the server changes between retries, resuming will result in a corrupted file. You can use the `If-Range` header to handle this safely.
+-   **Resource Cleanup:** Ensure files and response bodies are always closed to prevent resource leaks during multiple retry attempts.
+
+---
+
+## Conclusion
+
+Building resilient systems isn't just about handling errors; it's about handling them *efficiently*. By combining the standard HTTP `Range` protocol with Resile's powerful retry capabilities, you can create a download experience that is both robust and bandwidth-efficient.
+
+Check out the full [Streaming HTTP Resumption Example](https://github.com/cinar/resile/tree/main/examples/http_resume_stream) in the Resile repository to see this pattern in action.

--- a/examples/http_resume_stream/main.go
+++ b/examples/http_resume_stream/main.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Onur Cinar.
+// The source code is provided under MIT License.
+// https://github.com/cinar/resile
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cinar/resile"
+)
+
+func main() {
+	// 1. Setup Mock Server Data
+	const fileSize = 50 * 1024 // 50KB
+	const fileName = "downloaded.bin"
+	fileContent := make([]byte, fileSize)
+	for i := range fileContent {
+		fileContent[i] = byte(i % 256)
+	}
+
+	// 2. Start a Mock HTTP Server that supports Range requests and simulates failures.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rangeHeader := r.Header.Get("Range")
+		start := int64(0)
+		isPartial := false
+
+		if rangeHeader != "" && strings.HasPrefix(rangeHeader, "bytes=") {
+			parts := strings.Split(strings.TrimPrefix(rangeHeader, "bytes="), "-")
+			if len(parts) > 0 && parts[0] != "" {
+				s, err := strconv.ParseInt(parts[0], 10, 64)
+				if err == nil {
+					start = s
+					isPartial = true
+				}
+			}
+		}
+
+		if start >= fileSize {
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+
+		if isPartial {
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, fileSize-1, fileSize))
+			w.WriteHeader(http.StatusPartialContent)
+			fmt.Printf("[Server] Resuming from byte %d\n", start)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			fmt.Println("[Server] Starting new download")
+		}
+
+		// Simulate a connection drop midway through the remaining data.
+		// We'll fail roughly 60% of the time to demonstrate multiple retries.
+		remaining := fileSize - start
+		failAfter := int64(-1)
+		if rand.Float32() < 0.6 && remaining > 1024 {
+			failAfter = rand.Int64N(remaining-512) + 512
+		}
+
+		written := int64(0)
+		chunkSize := int64(1024)
+		for written < remaining {
+			if failAfter != -1 && written >= failAfter {
+				fmt.Printf("[Server] Simulating connection drop after %d bytes\n", written)
+				// Hijack the connection to force a close without a proper HTTP trailer/closure.
+				if hj, ok := w.(http.Hijacker); ok {
+					conn, _, _ := hj.Hijack()
+					conn.Close()
+					return
+				}
+				return
+			}
+
+			toWrite := chunkSize
+			if toWrite > remaining-written {
+				toWrite = remaining - written
+			}
+
+			n, err := w.Write(fileContent[start+written : start+written+toWrite])
+			if err != nil {
+				return
+			}
+			written += int64(n)
+		}
+	}))
+	defer server.Close()
+
+	fmt.Println("--- Streaming HTTP Response Resumption Example ---")
+
+	// 3. Resile execution state.
+	var bytesReceived int64
+	ctx := context.Background()
+
+	// Ensure the local file is clean.
+	os.Remove(fileName)
+	defer os.Remove(fileName)
+
+	// 4. Use resile.DoErr to handle retries.
+	err := resile.DoErr(ctx, func(ctx context.Context) error {
+		req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
+		if err != nil {
+			return err
+		}
+
+		// Request only the missing bytes.
+		if bytesReceived > 0 {
+			req.Header.Set("Range", fmt.Sprintf("bytes=%d-", bytesReceived))
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		// If server doesn't support 206, it might have returned 200 (full content).
+		// In that case, we must restart the local file.
+		fileFlags := os.O_APPEND | os.O_CREATE | os.O_WRONLY
+		if resp.StatusCode == http.StatusOK {
+			if bytesReceived > 0 {
+				fmt.Println("[Client] Server returned 200 OK, restarting download...")
+				bytesReceived = 0
+			}
+			fileFlags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+		} else if resp.StatusCode != http.StatusPartialContent {
+			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
+
+		f, err := os.OpenFile(fileName, fileFlags, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		// Stream content and update state.
+		// io.Copy will return an error if the connection drops.
+		n, err := io.Copy(f, resp.Body)
+		bytesReceived += n
+		fmt.Printf("[Client] Progress: %d/%d bytes received\n", bytesReceived, fileSize)
+
+		return err
+	},
+		resile.WithName("http-resume"),
+		resile.WithMaxAttempts(15), // Allow plenty of retries for the simulation.
+		resile.WithBackoff(resile.NewFullJitter(100*time.Millisecond, 1*time.Second)),
+	)
+
+	// 5. Final validation.
+	if err != nil {
+		fmt.Printf("Download failed: %v\n", err)
+		return
+	}
+
+	fmt.Println("Download completed successfully!")
+
+	// Verify file integrity.
+	downloaded, err := os.ReadFile(fileName)
+	if err != nil {
+		fmt.Printf("Error reading downloaded file: %v\n", err)
+		return
+	}
+
+	if int64(len(downloaded)) != fileSize {
+		fmt.Printf("Size mismatch: got %d, want %d\n", len(downloaded), fileSize)
+	} else if !bytes.Equal(downloaded, fileContent) {
+		fmt.Println("Content mismatch!")
+	} else {
+		fmt.Println("File integrity verified: content is correct.")
+	}
+}


### PR DESCRIPTION
Implement example for streaming HTTP response resumption using Range headers. Fixes #50.