### PR TITLE
Docs: Add YouTube and Dev.to social links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Codecov](https://codecov.io/gh/cinar/resile/branch/main/graph/badge.svg)](https://codecov.io/gh/cinar/resile)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cinar/resile)](https://goreportcard.com/report/github.com/cinar/resile)
 [![YouTube](https://img.shields.io/badge/YouTube-@resile--go-red?logo=youtube)](https://www.youtube.com/@resile-go)
+[![Dev.to](https://img.shields.io/badge/dev.to-onurcinar-0a0a0a?logo=dev.to&logoColor=white)](https://dev.to/onurcinar)
 
 **Resile** is a production-grade execution resilience and retry library for Go, inspired by Python's [stamina](https://github.com/hynek/stamina). It provides a type-safe, ergonomic, and highly observable way to handle transient failures in distributed systems.
 
@@ -97,7 +98,9 @@ Want to learn more about the philosophy behind Resile and advanced resilience pa
 * [Stopping the Zombie Requests: Distributed Deadline Propagation in Go](docs/articles/distributed-deadline-propagation.md)
 * [Reliable File Downloads with HTTP Range Resumption](docs/articles/streaming-http-resumption.md)
 
+Also, check out our [Dev.to space](https://dev.to/onurcinar) for more articles and discussions.
 
+---
 ## Examples
 
 The [examples/](examples/) directory contains standalone programs showing how to use Resile in various scenarios:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://github.com/cinar/resile/actions/workflows/ci.yml/badge.svg)](https://github.com/cinar/resile/actions/workflows/ci.yml)
 [![Codecov](https://codecov.io/gh/cinar/resile/branch/main/graph/badge.svg)](https://codecov.io/gh/cinar/resile)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cinar/resile)](https://goreportcard.com/report/github.com/cinar/resile)
+[![YouTube](https://img.shields.io/badge/YouTube-@resile--go-red?logo=youtube)](https://www.youtube.com/@resile-go)
 
 **Resile** is a production-grade execution resilience and retry library for Go, inspired by Python's [stamina](https://github.com/hynek/stamina). It provides a type-safe, ergonomic, and highly observable way to handle transient failures in distributed systems.
 
@@ -13,6 +14,8 @@
 ## See Resile in Action
 
 [![Resile Demo Video](https://img.youtube.com/vi/OCNQ-8gq0k8/0.jpg)](https://www.youtube.com/watch?v=OCNQ-8gq0k8)
+
+Subscribe to our [YouTube channel](https://www.youtube.com/@resile-go) for deep dives and tutorials.
 
 ---
 


### PR DESCRIPTION
Adds YouTube and Dev.to badges to the top of the README, and provides links to the respective channels and spaces in the See Resile in Action and Articles & Tutorials sections.